### PR TITLE
changed license to use valid SPDX shorthand format

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "homepage": "https://github.com/pokedex-net/pokedex-net-client",
   "bugs": "https://github.com/pokedex-net/pokedex-net-client/issues",
-  "license": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",
+  "license": "CC-BY-NC-SA-4.0",
   "author": {
     "name": "Elias Thompson",
     "email": "email@eliasthompson.com",


### PR DESCRIPTION
NPM was complaining about the license format - It should be using the shorthand, which I have changed it to.

![Screen Shot 2019-04-10 at 2 50 40 PM](https://user-images.githubusercontent.com/6880270/55916037-08150100-5ba0-11e9-8c6c-c5f993a2a53e.png)
